### PR TITLE
Use case-insensitive Windows environment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Pending
+-------
+
+* Passthrough case-insensitive PATH and SYSTEMROOT on Windows (@emillon,
+  @jonahbeckford)
+
 0.2.0 (07/09/2020)
 ------------------
 

--- a/curly.opam
+++ b/curly.opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/rgrinberg/curly"
 bug-reports: "https://github.com/rgrinberg/curly/issues"
 depends: [
   "dune" {>= "2.4"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.03.0"}
   "base-unix"
   "result"
   "alcotest" {with-test}

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,7 @@
  (depends
   ;; General system dependencies
   (dune (>= 2.4))
-  (ocaml (>= 4.02.3))
+  (ocaml (>= 4.03.0))
   base-unix
   result
 

--- a/src/curly.ml
+++ b/src/curly.ml
@@ -162,19 +162,21 @@ let array_filter f a =
   |> List.filter f
   |> Array.of_list
 
-let is_prefix s ~prefix =
+let is_prefix_ci s ~prefix =
   let s_len = String.length s in
   let prefix_len = String.length prefix in
-  (s_len >= prefix_len) && String.equal (String.sub s 0 prefix_len) prefix
+  let s_lc = String.lowercase_ascii s in
+  let prefix_lc = String.lowercase_ascii prefix in
+  (s_len >= prefix_len) && String.equal (String.sub s_lc 0 prefix_len) prefix_lc
 
-let var_in vars env_string =
-  List.exists (fun var -> is_prefix ~prefix:(var ^ "=") env_string) vars
+let var_in_ci vars env_string =
+  List.exists (fun var -> is_prefix_ci ~prefix:(var ^ "=") env_string) vars
 
 let curl_env () =
   if Sys.win32 then
     let kept_variables = ["PATH"; "SYSTEMROOT"] in
     Unix.environment ()
-    |> array_filter (var_in kept_variables)
+    |> array_filter (var_in_ci kept_variables)
   else
     [||]
 


### PR DESCRIPTION
*This is an extension of https://github.com/rgrinberg/curly/pull/6*

On Windows environment entries are case-sensitive. It is up to the reader to do a case-insensitive search if required. This PR does a case-insensitive search so that `SystemRoot` and `SYSTEMROOT` are both recognized.

Also had to bump up OCaml requirements from 4.02.3 to 4.03.0 since using `String.lowercase_ascii`.