### PR TITLE
fix PATH environment for Unixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Pending
 
 * Passthrough case-insensitive PATH and SYSTEMROOT on Windows (@emillon,
   @jonahbeckford)
+* Passthrough PATH to Unixes too. (@bikal)
 
 0.2.0 (07/09/2020)
 ------------------

--- a/src/curly.ml
+++ b/src/curly.ml
@@ -173,12 +173,9 @@ let var_in_ci vars env_string =
   List.exists (fun var -> is_prefix_ci ~prefix:(var ^ "=") env_string) vars
 
 let curl_env () =
-  if Sys.win32 then
-    let kept_variables = ["PATH"; "SYSTEMROOT"] in
-    Unix.environment ()
-    |> array_filter (var_in_ci kept_variables)
-  else
-    [||]
+  let kept_variables = ["PATH"; "SYSTEMROOT"] in
+  Unix.environment ()
+  |> array_filter (var_in_ci kept_variables)
 
 let run prog args stdin_str =
   let (stdout, stdin, stderr) =


### PR DESCRIPTION
Fixes PATH environment being set on Unixes as well as other OSes. It seems this is required for NixOS too. 

Fixes https://github.com/rgrinberg/curly/issues/11