### PR TITLE
4.08 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.install
 _build
+_opam
 *.merlin

--- a/curly.opam
+++ b/curly.opam
@@ -9,9 +9,8 @@ homepage: "https://github.com/rgrinberg/curly"
 bug-reports: "https://github.com/rgrinberg/curly/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08"}
   "base-unix"
-  "result"
   "alcotest" {with-test}
   "cohttp-lwt-unix" {with-test}
   "odoc" {with-doc}

--- a/dune-project
+++ b/dune-project
@@ -12,9 +12,8 @@
  (name curly)
  (synopsis "Curly is a brain dead wrapper around the curl command line utility")
  (depends
-  (ocaml (>= 4.03.0))
+  (ocaml (>= 4.08))
   base-unix
-  result
 
   (alcotest :with-test)
   (cohttp-lwt-unix :with-test)

--- a/src/curly.mli
+++ b/src/curly.mli
@@ -76,7 +76,7 @@ val run
   -> ?args:string list
   -> ?follow_redirects:bool
   -> Request.t
-  -> (Response.t, Error.t) Result.result
+  -> (Response.t, Error.t) result
 
 val get
   : ?exe:string
@@ -84,7 +84,7 @@ val get
   -> ?headers:Header.t
   -> ?follow_redirects:bool
   -> string
-  -> (Response.t, Error.t) Result.result
+  -> (Response.t, Error.t) result
 (** Specialized version of {!run} for method [`GET]
     @since 0.2.0 *)
 
@@ -94,7 +94,7 @@ val head
   -> ?headers:Header.t
   -> ?follow_redirects:bool
   -> string
-  -> (Response.t, Error.t) Result.result
+  -> (Response.t, Error.t) result
 (** Specialized version of {!run} for method [`HEAD]
     @since 0.2.0 *)
 
@@ -104,7 +104,7 @@ val delete
   -> ?headers:Header.t
   -> ?follow_redirects:bool
   -> string
-  -> (Response.t, Error.t) Result.result
+  -> (Response.t, Error.t) result
 (** Specialized version of {!run} for method [`DELETE]
     @since 0.2.0 *)
 
@@ -115,7 +115,7 @@ val post
   -> ?body:string
   -> ?follow_redirects:bool
   -> string
-  -> (Response.t, Error.t) Result.result
+  -> (Response.t, Error.t) result
 (** Specialized version of {!run} for method [`POST]
     @since 0.2.0 *)
 
@@ -126,6 +126,6 @@ val put
   -> ?body:string
   -> ?follow_redirects:bool
   -> string
-  -> (Response.t, Error.t) Result.result
+  -> (Response.t, Error.t) result
 (** Specialized version of {!run} for method [`PUT]
     @since 0.2.0 *)

--- a/src/dune
+++ b/src/dune
@@ -3,4 +3,4 @@
 (library
  (name curly)
  (public_name curly)
- (libraries unix result))
+ (libraries unix))


### PR DESCRIPTION
This PR updates the minimum version to 4.08 (safe since the only public dependency of curly, `dune-release`, is already using 4.08 as minimum).

This has some advantages:

  * No need for the result package
  * No need for a shell wrapper, thus avoiding the headache of quoting arguments for the shell

There are some failing tests that have to be addressed though, but I'm putting the PR out there for discussion already.