### PR TITLE
Update metadata in dune-project

### DIFF
--- a/curly.opam
+++ b/curly.opam
@@ -2,14 +2,13 @@
 opam-version: "2.0"
 synopsis:
   "Curly is a brain dead wrapper around the curl command line utility"
-description: ""
 maintainer: ["rudi.grinberg@gmail.com"]
 authors: ["Rudi Grinberg"]
 license: "ISC"
 homepage: "https://github.com/rgrinberg/curly"
 bug-reports: "https://github.com/rgrinberg/curly/issues"
 depends: [
-  "dune" {>= "2.4"}
+  "dune" {>= "2.7"}
   "ocaml" {>= "4.03.0"}
   "base-unix"
   "result"
@@ -18,7 +17,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.4)
+(lang dune 2.7)
 (name curly)
 
 (generate_opam_files true)
@@ -6,17 +6,12 @@
 (authors "Rudi Grinberg")
 (maintainers "rudi.grinberg@gmail.com")
 (license ISC)
-(homepage "https://github.com/rgrinberg/curly")
-(source (uri "git+https://github.com/rgrinberg/curly.git"))
-(bug_reports "https://github.com/rgrinberg/curly/issues")
+(source (github rgrinberg/curly))
 
 (package
  (name curly)
  (synopsis "Curly is a brain dead wrapper around the curl command line utility")
- (description "") ; TODO
  (depends
-  ;; General system dependencies
-  (dune (>= 2.4))
   (ocaml (>= 4.03.0))
   base-unix
   result


### PR DESCRIPTION
- upgrade to 2.7 to use `{dev}` (patched in opam-repository)
- use `(source github)`
- remove manual dependency to dune
- remove empty description
