### PR TITLE
Avoid shell invocation

### DIFF
--- a/src/curly.ml
+++ b/src/curly.ml
@@ -234,11 +234,13 @@ let is_redirect_code status =
 
 let run ?(exe="curl") ?(args=[]) ?(follow_redirects=false) req =
   Request.validate req >>= fun req ->
-  let args = "-s" :: "-i" :: (Request.to_cmd_args req) @ args in
+  let args = "-si" :: (Request.to_cmd_args req) @ args in
   let args =
     if follow_redirects then "-L" :: args
     else args
   in
+  (* the first argument of args is always the executable name *)
+  let args = exe :: args in
   let res =
     try
       result_of_process_result (run exe args req.Request.body)

--- a/src/curly.ml
+++ b/src/curly.ml
@@ -179,10 +179,8 @@ let curl_env () =
 
 let run prog args stdin_str =
   let (stdout, stdin, stderr) =
-    let prog =
-      prog :: (List.map Filename.quote args)
-      |> String.concat " " in
-    Unix.open_process_full prog (curl_env ()) in
+    let args = Array.of_list args in
+    Unix.open_process_args_full prog args (curl_env ()) in
   if String.length stdin_str > 0 then (
     output_string stdin stdin_str
   );

--- a/src/curly.ml
+++ b/src/curly.ml
@@ -234,11 +234,10 @@ let is_redirect_code status =
 
 let run ?(exe="curl") ?(args=[]) ?(follow_redirects=false) req =
   Request.validate req >>= fun req ->
+  let args = "-s" :: "-i" :: (Request.to_cmd_args req) @ args in
   let args =
-    if follow_redirects then
-      "-L" :: "-si" :: (Request.to_cmd_args req) @ args
-    else
-      "-si" :: (Request.to_cmd_args req) @ args
+    if follow_redirects then "-L" :: args
+    else args
   in
   let res =
     try

--- a/test/test_curly.ml
+++ b/test/test_curly.ml
@@ -65,22 +65,22 @@ let body_header b = ["content-length", string_of_int (String.length b)]
 
 let run_simple_get _ =
   Alcotest.check t_result "simple_get"
-    (Curly.run (with_path "simple_get"))
     (Ok { Response.code = 200
         ; body="curly"
         ; headers = body_header simple_get_body
         }
     )
+    (Curly.run (with_path "simple_get"))
 ;;
 
 let read_header _ =
   let (k, v) = ("x-curly", "header value") in
   Alcotest.check t_result "read_header"
-    (Curly.run { (with_path "read_header") with Request.headers = [k, v] })
     (Ok { Response.code = 200
         ; body = v
         ; headers = body_header v
         })
+    (Curly.run { (with_path "read_header") with Request.headers = [k, v] })
 ;;
 
 let write_body _ =


### PR DESCRIPTION
Depends on #13 to lift the dependencies to 4.08 which is required for `Unix.open_process_args_full`.

This changes the logic of the `curl` invocation to avoid requiring a shell. The upside is that there is one less process in the chain (`/bin/sh`) and we avoid the quoting/unquoting nightmare for shells, the downside is that this requires 4.08.

But that should be fine since curly's dependencies already require 4.08 and that version has been around for long enough that it's probably ok to bump to get some useful features.